### PR TITLE
docs: expand README with setup instructions and MDX component usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ For video content:
 Configuration:
 
 - `aspectRatio` - Prevents layout shift during loading ('16/9', '4/3', 'square', etc.)
-- `priority` - Set to `true` for above-the-fold content that should load immediately.
+- `priority` - Set to `true` for above-the-fold content that should load immediately
 - Standard HTML video attributes (`controls`, `loop`, `muted`, `autoplay`) are supported
 
 ### Callout

--- a/README.md
+++ b/README.md
@@ -1,17 +1,148 @@
 # David's Portfolio [![Deploy to GitHub Pages](https://github.com/totallynotdavid/totallynotdavid.github.io/actions/workflows/deploy.yml/badge.svg)](https://github.com/totallynotdavid/totallynotdavid.github.io/actions/workflows/deploy.yml)
 
-This repo contains the source code for my personal website built using Astro + MDX +
-Tailwind.
+This repo contains the source code for my personal website. The site is built with
+[Astro](https://astro.build/), [Tailwind CSS](https://tailwindcss.com/) and MDX. You can
+view the live site at [totallynotdavid.github.io](https://totallynotdavid.github.io).
 
-## Running Locally
+The site is a place for my writing and a playground for building things I find
+interesting.
 
-Install deps and start the dev server:
+## Getting Started
 
+To run the project locally, you'll need Bun. If you don't have Bun, you can install it
+from [bun.sh](https://bun.sh/) or use npm/pnpm/yarn as alternatives.
+
+First, clone the repository to your local machine:
+
+```bash
+git clone https://github.com/totallynotdavid/totallynotdavid.github.io.git
+cd totallynotdavid.github.io
 ```
+
+Install dependencies and run the development server:
+
+```bash
 bun install
 bun dev
 ```
 
-––-
+The site will be available at `http://localhost:4321`.
 
-If something here helps you, feel free to reach out or open an issue.
+## Custom MDX Components
+
+This site uses custom interactive components within MDX content. Here's how to use each
+one:
+
+### Annotation
+
+It lets you to add contextual side notes to your text, similar to margin notes in academic
+papers or books. On desktop, comments appear alongside the text with an animated SVG
+bracket connecting them. On mobile devices, the layout adapts to display comments beneath
+the annotated text.
+
+To use the Annotation component, import it in your MDX file and wrap the text you want to
+annotate. The main content goes in the default slot, while the annotation goes in the set
+slot.
+
+```mdx
+import Annotation from '@/components/mdx/Annotation.astro';
+
+<Annotation>
+  New students are left out. They can't access years of accumulated knowledge that could
+  help them prepare.
+  <Fragment
+    slot='comment'
+    set:text='Relationships between upperclassmen and underclassmen can be problematic'
+  />
+</Annotation>
+```
+
+You can set:
+
+- The `commentMaxWidth` to control the maximum width of the comment box in pixels
+  (defaults to 260).
+- The `mobileBreakpoint` prop determines the screen width threshold for switching to
+  mobile layout (defaults to 768px).
+
+If you prefer to disable the drawing animation, set `disableAnimation` to true.
+
+### MediaEmbed
+
+It lets you embed images, videos, and iframes. The component implements lazy loading,
+displays skeleton placeholders during loading, and includes error handling with retry
+functionality. It automatically detects media types based on file extensions, so you
+typically don't need to specify the type manually.
+
+For images, especially local assets, you should import the image file directly. The setup
+makes use of the Astro <Image/> and <Picture/> components for optimal loading and
+responsiveness when needed.
+
+```mdx
+---
+import heroImage from '@/assets/pics.jpeg';
+---
+
+import MediaEmbed from '@/components/mdx/MediaEmbed.astro';
+
+<MediaEmbed
+  src={heroImage}
+  alt='A descriptive alt text for the image'
+  caption='An optional caption that appears below the image.'
+  aspectRatio='square'
+/>
+```
+
+For video content:
+
+```mdx
+<MediaEmbed
+  src='/videos/my-cool-video.mp4'
+  caption='A video of something cool.'
+  controls
+  loop
+/>
+```
+
+The component supports various configuration options:
+
+- The `aspectRatio` prop accepts values like '16/9', '4/3', or 'square' to prevent layout
+  shift during loading.
+- Set `priority` to true for above-the-fold content that should load immediately.
+
+Standard HTML video attributes like `controls`, `loop`, `muted`, and `autoplay` are also
+supported.
+
+### Callout
+
+Adds a visually distinct link block that draws attention to important external resources.
+It's particularly useful for highlighting references, related content, or calls to action
+within your writing.
+
+```mdx
+import Callout from '@/components/mdx/Callout.astro';
+
+<Callout href='https://caefisica.com'>
+  <p>
+    Check us out. <span class='pl-1 text-gray-500'>Visit caefisica.com</span>
+  </p>
+</Callout>
+```
+
+The component requires only an `href` prop specifying the destination URL. The content can
+include any HTML or Markdown elements you need.
+
+### Mark
+
+It applies a subtle highlighter effect to text using CSS gradients for a more natural
+appearance than solid background colors.
+
+```mdx
+import Mark from '@/components/mdx/Mark.astro';
+
+You need to <Mark>self-study effectively</Mark> to succeed in this career.
+```
+
+You can customize the highlight color by passing a `color` prop with any valid CSS color
+value, such as 'rgba(245, 40, 145, 0.8)'. The component uses the `<mark>` HTML element by
+default, but you can change this by setting the `as` prop to a different element like
+`<span>` if needed.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ view the live site at [totallynotdavid.github.io](https://totallynotdavid.github
 The site is a place for my writing and a playground for building things I find
 interesting.
 
-## Getting Started
+## Getting started
 
 To run the project locally, you'll need Bun. If you don't have Bun installed, grab it from
 [bun.sh](https://bun.sh/) or use npm/pnpm/yarn as alternatives.

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ interesting.
 
 ## Getting Started
 
-To run the project locally, you'll need Bun. If you don't have Bun, you can install it
-from [bun.sh](https://bun.sh/) or use npm/pnpm/yarn as alternatives.
+To run the project locally, you'll need Bun. If you don't have Bun installed, grab it from
+[bun.sh](https://bun.sh/) or use npm/pnpm/yarn as alternatives.
 
-First, clone the repository to your local machine:
+First, clone the repository:
 
 ```bash
 git clone https://github.com/totallynotdavid/totallynotdavid.github.io.git
@@ -35,60 +35,47 @@ one:
 
 ### Annotation
 
-It lets you to add contextual side notes to your text, similar to margin notes in academic
-papers or books. On desktop, comments appear alongside the text with an animated SVG
-bracket connecting them. On mobile devices, the layout adapts to display comments beneath
-the annotated text.
-
-To use the Annotation component, import it in your MDX file and wrap the text you want to
-annotate. The main content goes in the default slot, while the annotation goes in the set
-slot.
+Add contextual side notes to your text, similar to margin notes in academic papers. On
+desktop, annotations appear alongside the text with animated SVG brackets. On mobile, they
+adapt to display underneath the annotated content.
 
 ```mdx
 import Annotation from '@/components/mdx/Annotation.astro';
 
 <Annotation>
-  New students are left out. They can't access years of accumulated knowledge that could
-  help them prepare.
+  This is the main text that readers will see inline.
   <Fragment
     slot='comment'
-    set:text='Relationships between upperclassmen and underclassmen can be problematic'
+    set:text='This annotation provides additional context or commentary'
   />
 </Annotation>
 ```
 
-You can set:
+Configuration:
 
-- The `commentMaxWidth` to control the maximum width of the comment box in pixels
-  (defaults to 260).
-- The `mobileBreakpoint` prop determines the screen width threshold for switching to
-  mobile layout (defaults to 768px).
-
-If you prefer to disable the drawing animation, set `disableAnimation` to true.
+- `commentMaxWidth` - Maximum width of the comment box in pixels (default: 260)
+- `mobileBreakpoint` - Screen width threshold for mobile layout (default: 768px)
+- `disableAnimation` - Set to `true` to disable the drawing animation
 
 ### MediaEmbed
 
-It lets you embed images, videos, and iframes. The component implements lazy loading,
-displays skeleton placeholders during loading, and includes error handling with retry
-functionality. It automatically detects media types based on file extensions, so you
-typically don't need to specify the type manually.
+Embed images, videos, and iframes with lazy loading, skeleton placeholders, and error
+handling. The component automatically detects media types based on file extensions.
 
-For images, especially local assets, you should import the image file directly. The setup
-makes use of the Astro <Image/> and <Picture/> components for optimal loading and
-responsiveness when needed.
+For images (especially local assets), import the file directly:
 
 ```mdx
 ---
-import heroImage from '@/assets/pics.jpeg';
+import myImage from '@/assets/example-image.jpg';
 ---
 
 import MediaEmbed from '@/components/mdx/MediaEmbed.astro';
 
 <MediaEmbed
-  src={heroImage}
-  alt='A descriptive alt text for the image'
-  caption='An optional caption that appears below the image.'
-  aspectRatio='square'
+  src={myImage}
+  alt='Descriptive alt text for accessibility'
+  caption='Optional caption that appears below the media'
+  aspectRatio='16/9'
 />
 ```
 
@@ -96,53 +83,50 @@ For video content:
 
 ```mdx
 <MediaEmbed
-  src='/videos/my-cool-video.mp4'
-  caption='A video of something cool.'
+  src='/videos/example-video.mp4'
+  caption='Video demonstrating a concept'
   controls
   loop
 />
 ```
 
-The component supports various configuration options:
+Configuration:
 
-- The `aspectRatio` prop accepts values like '16/9', '4/3', or 'square' to prevent layout
-  shift during loading.
-- Set `priority` to true for above-the-fold content that should load immediately.
-
-Standard HTML video attributes like `controls`, `loop`, `muted`, and `autoplay` are also
-supported.
+- `aspectRatio` - Prevents layout shift during loading ('16/9', '4/3', 'square', etc.)
+- `priority` - Set to `true` for above-the-fold content that should load immediately.
+- Standard HTML video attributes (`controls`, `loop`, `muted`, `autoplay`) are supported
 
 ### Callout
 
-Adds a visually distinct link block that draws attention to important external resources.
-It's particularly useful for highlighting references, related content, or calls to action
-within your writing.
+Create visually distinct blocks that draw attention to important links or external
+resources. Perfect for highlighting references, related content, or calls to action.
 
 ```mdx
 import Callout from '@/components/mdx/Callout.astro';
 
-<Callout href='https://caefisica.com'>
+<Callout href='https://example.com'>
   <p>
-    Check us out. <span class='pl-1 text-gray-500'>Visit caefisica.com</span>
+    Explore this related resource.
+    <span class='pl-1 text-gray-500'>Visit example.com</span>
   </p>
 </Callout>
 ```
 
-The component requires only an `href` prop specifying the destination URL. The content can
-include any HTML or Markdown elements you need.
+The component requires only an `href` prop. Content can include any HTML or Markdown
+elements.
 
 ### Mark
 
-It applies a subtle highlighter effect to text using CSS gradients for a more natural
-appearance than solid background colors.
+Apply subtle highlighter effects to text using CSS gradients for a more natural appearance
+than solid backgrounds.
 
 ```mdx
 import Mark from '@/components/mdx/Mark.astro';
 
-You need to <Mark>self-study effectively</Mark> to succeed in this career.
+This is regular text with <Mark>highlighted content</Mark> for emphasis.
 ```
 
-You can customize the highlight color by passing a `color` prop with any valid CSS color
-value, such as 'rgba(245, 40, 145, 0.8)'. The component uses the `<mark>` HTML element by
-default, but you can change this by setting the `as` prop to a different element like
-`<span>` if needed.
+Configuration:
+
+- `color` - Custom highlight color (any valid CSS color value)
+- `as` - Change the HTML element (default: `<mark>`, alternative: `<span>`)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# David's Portfolio [![Deploy to GitHub Pages](https://github.com/totallynotdavid/totallynotdavid.github.io/actions/workflows/deploy.yml/badge.svg)](https://github.com/totallynotdavid/totallynotdavid.github.io/actions/workflows/deploy.yml)
+# David's portfolio [![deploy](https://github.com/totallynotdavid/totallynotdavid.github.io/actions/workflows/deploy.yml/badge.svg)](https://github.com/totallynotdavid/totallynotdavid.github.io/actions/workflows/deploy.yml)
 
 This repo contains the source code for my personal website. The site is built with
 [Astro](https://astro.build/), [Tailwind CSS](https://tailwindcss.com/) and MDX. You can

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bun dev
 
 The site will be available at `http://localhost:4321`.
 
-## Custom MDX Components
+## Custom MDX components
 
 This site uses custom interactive components within MDX content. Here's how to use each
 one:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
-# David's Portfolio
+# David's Portfolio [![Deploy to GitHub Pages](https://github.com/totallynotdavid/totallynotdavid.github.io/actions/workflows/deploy.yml/badge.svg)](https://github.com/totallynotdavid/totallynotdavid.github.io/actions/workflows/deploy.yml)
 
-Welcome to the repository of my portfolio website! This website is dedicated to showcasing
-my work as an Undergraduate Physics student with a focus on Computational Physics and
-Fluid Dynamics.
+This repo contains the source code for my personal website built using Astro + MDX +
+Tailwind.
 
-## Contact
+## Running Locally
 
-If you have any questions or would like to get in touch with me, please don't hesitate to
-send me an email at david [at] caefisica.com
+Install deps and start the dev server:
+
+```
+bun install
+bun dev
+```
+
+––-
+
+If something here helps you, feel free to reach out or open an issue.


### PR DESCRIPTION
This patch updates `README.md` to improve onboardinge. The changes add a clearer project introduction, detailed local setup steps, and documentation for custom MDX components.

Changes:

* Update introduction
  * Highlight technology stack (`Astro`, `Tailwind CSS`, MDX).
  * Add link to live site.

* Add "Getting started" section
  * Step-by-step local setup with dependency installation.
  * Include Bun installation instructions.

* Document custom MDX components
  * Added usage and config details for `Annotation`, `MediaEmbed`, `Callout`, and `Mark`.
  * Include props descriptions and code examples.