### PR TITLE
ci: add PR build workflow and refine deploy triggers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,15 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [master]
+    branches:
+      - 'master'
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'package.json'
+      - 'astro.config.ts'
+      - 'tailwind.config.ts'
+      - 'tsconfig.json'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -2,7 +2,10 @@ name: Build on PR
 
 on:
   pull_request:
-    branches: [master]
+    branches:
+      - 'master'
+    paths:
+      - 'src/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,50 @@
+name: Build on PR
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-build-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build-check:
+    name: Validate Astro project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.19
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun x prettier --check .
+
+      - run: bun astro check
+
+      - run: bun run build
+
+      - name: Verify dist produced
+        run: |
+          test -d dist || { echo 'dist/ not found'; exit 1; }
+          echo "dist size:" $(du -sh dist | cut -f1)
+
+      - name: Ensure no unintended file changes
+        run: |
+          git diff --name-only --exit-code || {
+            echo 'The build or checks modified tracked files. Please commit those changes.';
+            git diff --stat; exit 1; }
+
+      # Optional: Upload build artifact for manual inspection (commented out to save minutes)
+      # - name: Upload build artifact
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: dist
+      #     path: dist
+      #     retention-days: 7

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -3,6 +3,7 @@ name: Build on PR
 on:
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
This patch improves CI/CD workflows by adding automated build checks for pull requests and narrowing deploy triggers to relevant changes.

Changes:

* Add `.github/workflows/pr-build.yml`
  * Runs on PRs targeting `master`.
  * Checks out code, installs dependencies, runs formatting and type checks, builds, verifies output, and ensures no unintended file changes.

* Update `.github/workflows/deploy.yml`
  * Triggers only when build-related files or directories change.
  * Reduces unnecessary deploy runs.